### PR TITLE
GCamGOPrebuilt: Add GCamGOPrebuilt-V4

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -4,11 +4,11 @@ android_app_import {
 	apk: "GCamGOPrebuilt.apk",
 	presigned: true,
 	dex_preopt: {
-		enabled: false,
+	enabled: false,
 	},
 	privileged: true,
 	product_specific: true,
-	overrides: ["Camera2", "GCamGOPrebuilt-V2", "GCamGOPrebuilt-V3", "Snap", "Aperture", "GoogleCamera"],
+	overrides: ["Camera2", "GCamGOPrebuilt-V2", "GCamGOPrebuilt-V3", "GCamGOPrebuilt-V4", "Snap", "Aperture", "GoogleCamera"],
 }
 
 android_app_import {
@@ -17,22 +17,35 @@ android_app_import {
 	apk: "GCamGOPrebuilt-V2.apk",
 	presigned: true,
 	dex_preopt: {
-		enabled: false,
+	enabled: false,
 	},
 	privileged: true,
 	product_specific: true,
-	overrides: ["Camera2", "GCamGOPrebuilt", "GCamGOPrebuilt-V3", "Snap", "Aperture", "GoogleCamera"],
+	overrides: ["Camera2", "GCamGOPrebuilt", "GCamGOPrebuilt-V3", "GCamGOPrebuilt-V4", "Snap", "Aperture", "GoogleCamera"],
 }
 
 android_app_import {
-        name: "GCamGOPrebuilt-V3",
-        owner: "google",
-        apk: "GCamGOPrebuilt-V3.apk",
-        presigned: true,
-        dex_preopt: {
-		enabled: false,
+	name: "GCamGOPrebuilt-V3",
+	owner: "google",
+	apk: "GCamGOPrebuilt-V3.apk",
+	presigned: true,
+	dex_preopt: {
+	enabled: false,
 	},
 	privileged: true,
-        product_specific: true,
-        overrides: ["Camera2", "GCamGOPrebuilt", "GCamGOPrebuilt-V2", "Snap", "Aperture", "GoogleCamera"],
+	product_specific: true,
+	overrides: ["Camera2", "GCamGOPrebuilt", "GCamGOPrebuilt-V2", "GCamGOPrebuilt-V4", "Snap", "Aperture", "GoogleCamera"],
+}
+
+android_app_import {
+	name: "GCamGOPrebuilt-V4",
+	owner: "google",
+	apk: "GCamGOPrebuilt-V4.apk",
+	presigned: true,
+	dex_preopt: {
+	enabled: false,
+	},
+	privileged: true,
+	product_specific: true,
+	overrides: ["Camera2", "GCamGOPrebuilt", "GCamGOPrebuilt-V2", "GCamGOPrebuilt-V3", "Snap", "Aperture", "GoogleCamera"],
 }

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ PRODUCT_PACKAGES += \
     GCamGOPrebuilt
 ```
 
-## Latest GCamGOPrebuilt packages (Experimental)
+## Latest GCamGOPrebuilt packages (Stable)
 ```
 PRODUCT_PACKAGES += \
-    GCamGOPrebuilt-V3
+    GCamGOPrebuilt-V4
 ```
 
 | Source |


### PR DESCRIPTION
Add GCamGOPrebuilt-V4 from SGCAM_GO_3.8.47_STABLE_V1.apk (com.google.android.apps.cameralite)

Source: https://www.celsoazevedo.com/files/android/google-camera/dev-shamim/f/dl31/